### PR TITLE
1.4-lookup-service-authlist

### DIFF
--- a/src/main/java/ccm/CcmLookupService.java
+++ b/src/main/java/ccm/CcmLookupService.java
@@ -407,6 +407,8 @@ public class CcmLookupService extends RouteBuilder {
       }
     })
     .marshal().json(JsonLibrary.Jackson, AuthUserList.class)
+    // remove the pidp token header, as it causes bad requests from JUSTIN side.
+    .removeHeaders("pidp*")
     .log(LoggingLevel.DEBUG, "Body: ${body}")
     .end();
   }

--- a/src/main/java/ccm/CcmNotificationService.java
+++ b/src/main/java/ccm/CcmNotificationService.java
@@ -542,6 +542,7 @@ public class CcmNotificationService extends RouteBuilder {
         .marshal().json(JsonLibrary.Jackson, ReportEvent.class)
         .delay(30000)
         .to("kafka:{{kafka.topic.reports.name}}")
+        .log(LoggingLevel.INFO, "Completed processChargeAssessmentCreated")
       .endChoice()
     .otherwise()
       .log(LoggingLevel.WARN, "Skipping creation of DEMS Case: ${header.event_key}")
@@ -1917,6 +1918,7 @@ public class CcmNotificationService extends RouteBuilder {
     .marshal().json(JsonLibrary.Jackson, ReportEvent.class)
     .delay(60000)
     .to("kafka:{{kafka.topic.reports.name}}")
+    .log(LoggingLevel.INFO, "Completed processCourtCaseChanged")
     ;
   }
 


### PR DESCRIPTION
Removed the pidp token from the headers, as it was causing issues for… JUSTIN API calls.