### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to OpenShift
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/jpss-jade-ccm/security/code-scanning/3](https://github.com/bcgov/jpss-jade-ccm/security/code-scanning/3)

The problem is that the workflow (or, specifically, the `deploy` job) does not define a `permissions` block, so it inherits possibly unsafe default permissions for the GITHUB_TOKEN. The best fix is to add a `permissions` block at the root level of the workflow (i.e., after `name:` but before `on:` or `jobs:`) with the least privilege required. For this workflow, `contents: read` is likely sufficient, since no actions in the workflow seem to require write access. To implement this, add:

```yaml
permissions:
  contents: read
```

after the `name: Deploy to OpenShift` line and before the `on:` block (recommended practice).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
